### PR TITLE
Optimize FieldLocation

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
@@ -165,10 +165,8 @@ public final class FieldLocation implements Comparable<FieldLocation> {
 
   @Override
   public int hashCode() {
-    int result = Objects.hashCode(pathToUseInRules);
-    result = 31 * result + Objects.hashCode(decomposedPath);
-    result = 31 * result + Objects.hashCode(pathsHierarchyToUseInRules);
-    return result;
+    // cheap hashCode as other fields are effectively derived from pathToUseInRules
+    return pathToUseInRules.hashCode();
   }
 
   @Override

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
@@ -167,7 +167,7 @@ public final class FieldLocation implements Comparable<FieldLocation> {
   @Override
   public int hashCode() {
     // cheap hashCode as other fields are effectively derived from pathToUseInRules
-    return pathToUseInRules.hashCode();
+    return Objects.hashCode(pathToUseInRules);
   }
 
   @Override

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
@@ -17,7 +17,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.util.Lists.list;
-import static org.assertj.core.util.Sets.newHashSet;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -266,7 +266,7 @@ public final class FieldLocation implements Comparable<FieldLocation> {
   }
 
   private Set<String> pathsHierarchyToUseInRules() {
-    Set<String> fieldAndParentFields = newHashSet();
+    Set<String> fieldAndParentFields = newLinkedHashSet();
     String currentPath = this.pathToUseInRules;
     while (!isRootPath(currentPath)) {
       fieldAndParentFields.add(currentPath);

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
@@ -264,6 +264,8 @@ public final class FieldLocation implements Comparable<FieldLocation> {
   }
 
   private Set<String> pathsHierarchyToUseInRules() {
+    // using LinkedHashSet to maintain leaf to root iteration order so that hierarchyMatchesRegex
+    // can try matching longest to shorted path
     Set<String> fieldAndParentFields = newLinkedHashSet();
     String currentPath = this.pathToUseInRules;
     while (!isRootPath(currentPath)) {

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
@@ -166,8 +166,10 @@ public final class FieldLocation implements Comparable<FieldLocation> {
 
   @Override
   public int hashCode() {
-    // cheap hashCode as other fields are effectively derived from pathToUseInRules
-    return Objects.hashCode(pathToUseInRules);
+    int result = Objects.hashCode(pathToUseInRules);
+    result = 31 * result + Objects.hashCode(decomposedPath);
+    result = 31 * result + Objects.hashCode(pathsHierarchyToUseInRules);
+    return result;
   }
 
   @Override

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
@@ -14,6 +14,7 @@ package org.assertj.core.api.recursive.comparison;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.util.Lists.list;
@@ -264,15 +265,15 @@ public final class FieldLocation implements Comparable<FieldLocation> {
   }
 
   private Set<String> pathsHierarchyToUseInRules() {
-    // using LinkedHashSet to maintain leaf to root iteration order so that hierarchyMatchesRegex
-    // can try matching longest to shorted path
+    // using LinkedHashSet to maintain leaf to root iteration order
+    // so that hierarchyMatchesRegex can try matching longest to shorted path
     Set<String> fieldAndParentFields = newLinkedHashSet();
     String currentPath = this.pathToUseInRules;
     while (!isRootPath(currentPath)) {
       fieldAndParentFields.add(currentPath);
       currentPath = parent(currentPath);
     }
-    return Collections.unmodifiableSet(fieldAndParentFields);
+    return unmodifiableSet(fieldAndParentFields);
   }
 
   private String parent(String currentPath) {

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_Test.java
@@ -635,26 +635,26 @@ class RecursiveComparisonAssert_isEqualTo_Test extends RecursiveComparisonAssert
     p19a.neighbour = p20a;
     p19b.neighbour = p20b;
 
-    // This fails at 15sec > 10sec on my 2021 Apple M1 Pro.  Uncomment more references below to increase the time. Every
+    // This fails at 15sec > 10sec on my 2021 Apple M1 Pro. Uncomment more references below to increase the time. Every
     // additional link roughly doubles the execution time.
 
-//    p20a.neighbour = p21a;
-//    p20b.neighbour = p21b;
+    p20a.neighbour = p21a;
+    p20b.neighbour = p21b;
 
-//    p21a.neighbour = p22a;
-//    p21b.neighbour = p22b;
+    p21a.neighbour = p22a;
+    p21b.neighbour = p22b;
 
-//    p22a.neighbour = p23a;
-//    p22b.neighbour = p23b;
+    p22a.neighbour = p23a;
+    p22b.neighbour = p23b;
 
-//    p23a.neighbour = p24a;
-//    p23b.neighbour = p24b;
+    p23a.neighbour = p24a;
+    p23b.neighbour = p24b;
 
-//    p24a.neighbour = p25a;
-//    p24b.neighbour = p25b;
+    p24a.neighbour = p25a;
+    p24b.neighbour = p25b;
 
-//    p25a.neighbour = p26a;
-//    p25b.neighbour = p26b;
+    p25a.neighbour = p26a;
+    p25b.neighbour = p26b;
 
     Stopwatch stopwatch = Stopwatch.createStarted();
     assertThat(p1a).usingRecursiveComparison().isEqualTo(p1b);


### PR DESCRIPTION
FieldLocation maintains set of paths to use in rules ordered from leaf to parent. The set provides O(1) hierarchyMatches operation.

This addresses the following trace from JFR running some test cases using assertj 3.25.2 using `usingRecursiveComparison().isEqualTo`

![image](https://github.com/ash211/assertj/assets/54594/7ed1e1b9-f113-48e8-bc16-281f6ea60f79)


#### Check List:
* Fixes #3350
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)



